### PR TITLE
chore: add missing ms-kubernetes-tools.vscode-kubernetes-tools and redhat.vscode-yaml extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,8 @@
     "recommendations": [
       "redhat.vscode-xml",  
       "redhat.vscode-apache-camel",
-      "redhat.vscode-camelk"    
+      "redhat.vscode-camelk",
+      "ms-kubernetes-tools.vscode-kubernetes-tools",
+      "redhat.vscode-yaml"
     ]
   }


### PR DESCRIPTION
Cherry-pick of https://github.com/devspaces-samples/camel-k/pull/1

Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

`redhat.vscode-camelk` plugin in Che plugin registry depends on `ms-kubernetes-tools.vscode-kubernetes-tools` and `redhat.vscode-yaml`.

To have the consistent workspace with che-code exitor, it needs to add corresponding extensions for that plugins.

Solves https://issues.redhat.com/browse/CRW-3302

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/camel-k?che-editor=che-incubator/che-code/insiders
