### PR TITLE
chore: add java and fabric8-analytics extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,11 +1,13 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=827846
-    // for the documentation about the extensions.json format
-    "recommendations": [
-      "redhat.vscode-xml",  
-      "redhat.vscode-apache-camel",
-      "redhat.vscode-camelk",
-      "ms-kubernetes-tools.vscode-kubernetes-tools",
-      "redhat.vscode-yaml"
-    ]
-  }
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "redhat.vscode-xml",
+    "redhat.vscode-apache-camel",
+    "redhat.vscode-camelk",
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "redhat.vscode-yaml",
+    "redhat.java",
+    "redhat.fabric8-analytics"
+  ]
+}


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Adds
- `redhat.java` extension as the project contains java samples
- `redhat.fabric8-analytics` as suitable for java and golang samples

Solves https://issues.redhat.com/browse/CRW-3302

Use following URI to create a workspace with factory
https://github.com/vitaliy-guliy/camel-k?che-editor=che-incubator/che-code/insiders
